### PR TITLE
allow empty url

### DIFF
--- a/src/templates/Mouf/Html/Widgets/Menu/MenuItem.twig
+++ b/src/templates/Mouf/Html/Widgets/Menu/MenuItem.twig
@@ -1,7 +1,7 @@
 {% if not this.hidden %}
 {% set menuCssClass = cssClass ~ (active?" active":"") %}
 <li{% if menuCssClass %} class="{{ menuCssClass }}"{% endif %}>
-{%- if url %}<a href="{{ this.link }}">{{ label }}</a>{% else %}{{ label }}{% endif -%}
+{%- if url is defined %}<a href="{{ this.link }}">{{ label }}</a>{% else %}{{ label }}{% endif -%}
 {% if children %}
 <ul>
 	{%- for child in children -%}


### PR DESCRIPTION
This allow to create a link to the root url of the web site by defining a empty link in the mouf interface.
